### PR TITLE
Revise Point Cloud Loading Service

### DIFF
--- a/reach_core/CMakeLists.txt
+++ b/reach_core/CMakeLists.txt
@@ -10,8 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   pcl_ros
   pluginlib
   reach_msgs
-  tf
-  tf_conversions
+  tf2_ros
+  tf2_eigen
   visualization_msgs
 )
 
@@ -39,8 +39,8 @@ catkin_package(
     pcl_ros
     pluginlib
     reach_msgs
-    tf
-    tf_conversions
+    tf2_ros
+    tf2_eigen
     visualization_msgs
 )
 
@@ -53,7 +53,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-# Utilites Library
+# Utilities Library
 add_library(reach_study_utils
   src/utils/general_utils.cpp
   src/utils/visualization_utils.cpp
@@ -139,14 +139,14 @@ add_dependencies(robot_reach_study_node
   ${catkin_EXPORTED_TARGETS}
 )
 
-# Sample Mesh Server Node
-add_executable(sample_mesh_server
-  src/sample_mesh_server_node.cpp
+# Load Point Cloud Server Node
+add_executable(load_point_cloud_server_node
+  src/load_point_cloud_server_node.cpp
 )
-target_link_libraries(sample_mesh_server
+target_link_libraries(load_point_cloud_server_node
   ${catkin_LIBRARIES}
 )
-add_dependencies(sample_mesh_server
+add_dependencies(load_point_cloud_server_node
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS}
 )
@@ -177,7 +177,7 @@ install(
     reach_study
     plugins
     robot_reach_study_node
-    sample_mesh_server
+    load_point_cloud_server_node
     data_loader
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/reach_core/CMakeLists.txt
+++ b/reach_core/CMakeLists.txt
@@ -26,12 +26,8 @@ catkin_package(
   INCLUDE_DIRS
     include
   LIBRARIES
-    reach_study_utils
-    reach_database
-    ik_helper
-    reach_visualizer
-    reach_study
-    plugins
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_plugins
   CATKIN_DEPENDS
     eigen_conversions
     geometry_msgs
@@ -53,76 +49,27 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-# Utilities Library
-add_library(reach_study_utils
+# Reach Study Library
+add_library(${PROJECT_NAME}
+  # Utilities
   src/utils/general_utils.cpp
   src/utils/visualization_utils.cpp
-)
-target_link_libraries(reach_study_utils
-  ${catkin_LIBRARIES}
-)
-add_dependencies(reach_study_utils
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
-# Reach Database Library
-add_library(reach_database
+  # Tools
   src/core/reach_database.cpp
-)
-target_link_libraries(reach_database
-  ${catkin_LIBRARIES}
-  reach_study_utils
-)
-add_dependencies(reach_database
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
-# IK Helper Library
-add_library(ik_helper
   src/core/ik_helper.cpp
-)
-target_link_libraries(ik_helper
-  ${catkin_LIBRARIES}
-  reach_database
-)
-add_dependencies(ik_helper
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
-# Reach Visualizer Library
-add_library(reach_visualizer
   src/core/reach_visualizer.cpp
-)
-target_link_libraries(reach_visualizer
-  ${catkin_LIBRARIES}
-  ik_helper
-)
-add_dependencies(reach_visualizer
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
-)
-
-# Reach Study Library
-add_library(reach_study
+  # Reach Study
   src/core/reach_study.cpp
 )
-target_link_libraries(reach_study
+target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
-  reach_visualizer
-)
-add_dependencies(reach_study
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
 )
 
 # Plugins Library
-add_library(plugins
+add_library(${PROJECT_NAME}_plugins
   src/plugins/impl/multiplicative_factory.cpp
 )
-target_link_libraries(plugins
+target_link_libraries(${PROJECT_NAME}_plugins
   ${catkin_LIBRARIES}
 )
 
@@ -132,7 +79,7 @@ add_executable(robot_reach_study_node
 )
 target_link_libraries(robot_reach_study_node
   ${catkin_LIBRARIES}
-  reach_study
+  ${PROJECT_NAME}
 )
 add_dependencies(robot_reach_study_node
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
@@ -157,7 +104,7 @@ add_executable(data_loader
 )
 target_link_libraries(data_loader
   ${catkin_LIBRARIES}
-  reach_database
+  ${PROJECT_NAME}
 )
 add_dependencies(data_loader
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
@@ -170,12 +117,8 @@ add_dependencies(data_loader
 
 install(
   TARGETS
-    reach_study_utils
-    reach_database
-    ik_helper
-    reach_visualizer
-    reach_study
-    plugins
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_plugins
     robot_reach_study_node
     load_point_cloud_server_node
     data_loader

--- a/reach_core/launch/setup.launch
+++ b/reach_core/launch/setup.launch
@@ -6,7 +6,7 @@
     <param name="visualize_results" value="$(arg rviz)"/>
     <include file="$(arg robot)"/>
 
-    <node name="sample_mesh_server" pkg="reach_core" type="sample_mesh_server" output="screen" required="true"/>
+    <node name="load_point_cloud_server" pkg="reach_core" type="load_point_cloud_server_node" output="screen" required="true"/>
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find reach_core)/config/reach_study_config.rviz" if="$(arg rviz)"/>
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>

--- a/reach_core/package.xml
+++ b/reach_core/package.xml
@@ -16,8 +16,8 @@
   <depend>pcl_ros</depend>
   <depend>pluginlib</depend>
   <depend>reach_msgs</depend>
-  <depend>tf</depend>
-  <depend>tf_conversions</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_eigen</depend>
   <depend>visualization_msgs</depend>
 
   <export>

--- a/reach_core/src/load_point_cloud_server_node.cpp
+++ b/reach_core/src/load_point_cloud_server_node.cpp
@@ -1,12 +1,12 @@
-/* 
+/*
  * Copyright 2019 Southwest Research Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,37 +17,12 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/PCLPointField.h>
 #include <pcl_ros/point_cloud.h>
-#include <reach_msgs/SampleMesh.h>
+#include <reach_msgs/LoadPointCloud.h>
 #include <ros/ros.h>
-#include <tf_conversions/tf_eigen.h>
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 const static std::string SAMPLE_MESH_SRV_TOPIC = "sample_mesh";
-
-bool getObjectTF(const std::string& fixed_frame,
-                 const std::string& object_frame,
-                 tf::StampedTransform& transform)
-{
-  tf::TransformListener listener;
-  if(listener.waitForTransform(fixed_frame, object_frame, ros::Time::now(), ros::Duration(5.0)))
-  {
-    try
-    {
-      listener.lookupTransform(fixed_frame, object_frame, ros::Time(0.0), transform);
-    }
-    catch(tf::TransformException ex)
-    {
-      ROS_ERROR("%s", ex.what());
-      return false;
-    }
-  }
-  else
-  {
-    ROS_ERROR("TF lookup between %s and %s has timed out", fixed_frame.c_str(), object_frame.c_str());
-    return false;
-  }
-  return true;
-}
 
 bool hasNormals(pcl::PCLPointCloud2& cloud)
 {
@@ -65,47 +40,65 @@ bool hasNormals(pcl::PCLPointCloud2& cloud)
   }
 }
 
-bool getSampledMesh(reach_msgs::SampleMeshRequest& req,
-                    reach_msgs::SampleMeshResponse& res)
+bool getSampledMesh(reach_msgs::LoadPointCloudRequest& req,
+                    reach_msgs::LoadPointCloudResponse& res)
 {
   // Check if file exists
   if(!boost::filesystem::exists(req.cloud_filename))
   {
-    ROS_ERROR("%s does not exist", req.cloud_filename.c_str());
-    return false;
+    res.message = "File '" + req.cloud_filename + "' does not exist";
+    res.success = false;
+
+    return true;
   }
 
   pcl::PCLPointCloud2 cloud_msg;
   if(pcl::io::loadPCDFile(req.cloud_filename, cloud_msg) == -1)
   {
-    ROS_ERROR("Unable to load point cloud .pcd file");
-    return false;
+    res.message = "Unable to load point cloud from '" + req.cloud_filename + "'";
+    res.success = false;
+    return true;
   }
 
   if(!hasNormals(cloud_msg))
   {
-    ROS_ERROR("Point cloud file does not contain normals. Please regenerate the cloud with normal vectors");
-    return false;
+    res.message = "Point cloud file does not contain normals. Please regenerate the cloud with "
+                  "normal vectors";
+    res.success = false;
+    return true;
   }
 
   pcl::PointCloud<pcl::PointNormal> cloud;
   pcl::fromPCLPointCloud2(cloud_msg, cloud);
 
   // Transform point cloud to correct frame
-  tf::StampedTransform object_tf;
-  if(!getObjectTF(req.fixed_frame, req.object_frame, object_tf))
+  tf2_ros::Buffer buffer;
+  tf2_ros::TransformListener listener(buffer);
+  Eigen::Isometry3d transform;
+  try
   {
-    return false;
+    geometry_msgs::TransformStamped tf = buffer.lookupTransform(req.fixed_frame,
+                                                                req.object_frame,
+                                                                ros::Time(0),
+                                                                ros::Duration(5.0));
+    transform = tf2::transformToEigen(tf.transform);
+  }
+  catch(const tf2::TransformException& ex)
+  {
+    res.message = ex.what();
+    res.success = false;
+    return true;
   }
 
-  Eigen::Isometry3d transform;
-  tf::transformTFToEigen(object_tf, transform);
   pcl::PointCloud<pcl::PointNormal> transformed_cloud;
   pcl::transformPointCloudWithNormals(cloud, transformed_cloud, transform.matrix());
 
   // Convert point cloud to message for output
   sensor_msgs::PointCloud2 msg;
   pcl::toROSMsg(transformed_cloud, res.cloud);
+
+  res.success = true;
+  res.message = "Successfully loaded point cloud from '" + req.cloud_filename + "'";
 
   return true;
 }

--- a/reach_msgs/CMakeLists.txt
+++ b/reach_msgs/CMakeLists.txt
@@ -15,7 +15,7 @@ add_message_files(
 
 add_service_files(
   FILES
-    SampleMesh.srv
+    LoadPointCloud.srv
 )
 
 generate_messages(

--- a/reach_msgs/srv/LoadPointCloud.srv
+++ b/reach_msgs/srv/LoadPointCloud.srv
@@ -6,3 +6,5 @@ string object_frame
 ---
 # Response Data
 sensor_msgs/PointCloud2 cloud
+bool success
+string message


### PR DESCRIPTION
This PR revises the service for loading a point cloud from file to provide better feedback on potential failure modes.

For the record, the reason loading of point clouds occurs in a separate executable rather than in the reach study itself is because early on I ran into runtime segfaults caused by boost IO interactions between PCL and the MoveIt Trac-IK plugin. I wasn't able to resolve these issues, so I moved the loading of point clouds into a separate thread. This strategy should probably be reevaluated at some point