### PR TITLE
Fixed bug in reach_core/launch/setup.launch

### DIFF
--- a/reach_core/launch/setup.launch
+++ b/reach_core/launch/setup.launch
@@ -10,5 +10,5 @@
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find reach_core)/config/reach_study_config.rviz" if="$(arg rviz)"/>
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 </launch>


### PR DESCRIPTION
Modified to launch the robot_state_publisher/robot_state_publisher node. Initial code attempted to launch robot_state_publisher/state_publisher, which doesn't exist.