### PR TITLE
Various Updates

### DIFF
--- a/moveit_reach_plugins/README.md
+++ b/moveit_reach_plugins/README.md
@@ -4,20 +4,36 @@ This package contains the plugin implemenations of REACH kinematics, evaluation,
 
 ## Evaluation Plugins
 
-### Manpiulability
+### Manipulability
 
-This plugin uses MoveIt! to calculate the manipulability of a robot pose. Higher manipulability results in higher pose score.
+This plugin uses MoveIt! to calculate the manipulability of a robot pose. Higher manipulability results in higher pose score. Range: [0, inf)
 
 Parameters:
 
 - **`planning_group`**
   - The name of the planning group with which to evaluate the manipulability of a given robot pose
+- **`jacobian_row_subset`** (optional)
+  - The indices of the rows of the Jacobian to use when evaluating the manipulability. The row indices should be on [0, 6) and correspond to the output space [x, y, z, rx, ry, rz]
+  - Ex. `jacobian_row_subset: [0, 1, 2]  # position manipulability only`
+
+### Manipulability Ratio
+
+This plugin uses MoveIt! to calculate the manipulability of a robot pose and evaluate a score. The score is calculated as the ratio of the smallest manipulability value to the largest manipulability value.
+The larger this ratio, the more uniform the dexterity and the higher the score. Range [0, 1]
+
+Parameters:
+
+- **`planning_group`**
+  - The name of the planning group with which to evaluate the manipulability of a given robot pose
+- **`jacobian_row_subset`** (optional)
+  - The indices of the rows of the Jacobian to use when evaluating the manipulability. The row indices should be on [0, 6) and correspond to the output space [x, y, z, rx, ry, rz]
+  - Ex. `jacobian_row_subset: [0, 1, 2]  # position manipulability only`
 
 ### Distance Penalty
 
 This plugin uses the MoveIt! collision environment to calculate the distance to closest collision
 for a robot pose. That distance value is then used to score the robot pose. Larger distance to closest collision
-results in higher pose score.
+results in higher pose score. Range: [0, inf)
 
 Parameters:
 
@@ -38,7 +54,7 @@ Parameters:
 ### Joint Penalty
 
 This plugin uses the MoveIt! robot model to calculate a robot pose score based on how much the pose deviates
-from the center of the joint range. Robot poses that are closer to the center of the joint range result in higher pose scores.
+from the center of the joint range. Robot poses that are closer to the center of the joint range result in higher pose scores. Range: [0, 1]
 
 Parameters:
 

--- a/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/joint_penalty_moveit.h
+++ b/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/joint_penalty_moveit.h
@@ -42,13 +42,14 @@ public:
   virtual double calculateScore(const std::map<std::string, double>& pose) override;
 
 private:
-  std::vector<std::vector<double>> getJointLimits();
+  std::tuple<std::vector<double>, std::vector<double>> getJointLimits();
 
   moveit::core::RobotModelConstPtr model_;
 
   const moveit::core::JointModelGroup* jmg_;
 
-  std::vector<std::vector<double>> joint_limits_;
+  std::vector<double> joints_min_;
+  std::vector<double> joints_max_;
 };
 
 }  // namespace evaluation

--- a/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/manipulability_moveit.h
+++ b/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/manipulability_moveit.h
@@ -43,8 +43,8 @@ public:
 
 private:
   moveit::core::RobotModelConstPtr model_;
-
   const moveit::core::JointModelGroup* jmg_;
+  std::vector<int> jacobian_row_subset_;
 };
 
 }  // namespace evaluation

--- a/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/manipulability_moveit.h
+++ b/moveit_reach_plugins/include/moveit_reach_plugins/evaluation/manipulability_moveit.h
@@ -16,6 +16,8 @@
 #ifndef MOVEIT_REACH_PLUGINS_EVALUATION_MANIPULABILITY_EVALUATION_H
 #define MOVEIT_REACH_PLUGINS_EVALUATION_MANIPULABILITY_EVALUATION_H
 
+#include <Eigen/Dense>
+
 #include <reach_core/plugins/evaluation_base.h>
 
 namespace moveit
@@ -41,10 +43,20 @@ public:
 
   virtual double calculateScore(const std::map<std::string, double>& pose) override;
 
-private:
+protected:
+  virtual double calculateScore(const Eigen::MatrixXd& jacobian_singular_values);
+
   moveit::core::RobotModelConstPtr model_;
   const moveit::core::JointModelGroup* jmg_;
   std::vector<int> jacobian_row_subset_;
+};
+
+class ManipulabilityRatio : public ManipulabilityMoveIt
+{
+public:
+  using ManipulabilityMoveIt::ManipulabilityMoveIt;
+
+  virtual double calculateScore(const Eigen::MatrixXd& jacobian_singular_values) override;
 };
 
 }  // namespace evaluation

--- a/moveit_reach_plugins/plugin_description.xml
+++ b/moveit_reach_plugins/plugin_description.xml
@@ -18,9 +18,9 @@
   <class name="moveit_reach_plugins/evaluation/JointPenaltyMoveIt" type="moveit_reach_plugins::evaluation::JointPenaltyMoveIt" base_class_type="reach::plugins::EvaluationBase">
     <description>
       A pose evaluation plugin which returns a score that is the product of each joint's distance from the middle of its joint range, according to the following equation:
-      score[i] = ((joint[i] - joint_min[i])*(joint_max[i] - joint[i])) / (joint_max[i] - joint_min[i])^2
-      The score for each joint will lie in the range [0, 0.25]; therefore, the score for an entire robot will lie in the range n*[0, 0.25], where n is the number of joints
-      in the robot. Higher scores indicate poses which are closer to the nominal middle of travel of each joint. This plugin should be used if it is desirable for kinematic
+      score[i] = 4 * ((joint[i] - joint_min[i])*(joint_max[i] - joint[i])) / (joint_max[i] - joint_min[i])^2
+      The score for each joint will lie in the range [0, 1.0], and the total score is the mean of the scores of the individual joints.
+      Higher scores indicate poses which are closer to the nominal middle of travel of each joint. This plugin should be used if it is desirable for kinematic
       solutions to be near the middle of all joint ranges.
     </description>
   </class>

--- a/moveit_reach_plugins/plugin_description.xml
+++ b/moveit_reach_plugins/plugin_description.xml
@@ -7,6 +7,12 @@
       Higher scores indicate higher robot dexterity at a given pose.
     </description>
   </class>
+  <class name="moveit_reach_plugins/evaluation/ManipulabilityRatio" type="moveit_reach_plugins::evaluation::ManipulabilityRatio" base_class_type="reach::plugins::EvaluationBase">
+    <description>
+      A pose evalution plugin which returns a score (range [0, 1]) that is the ratio of smallest to largest manipulability values of robot at the input pose calculated from the robot's Jacobian.
+      Higher scores indicate more uniform dexterity at a given pose.
+    </description>
+  </class>
 
   <!-- Joint Penalty MoveIt -->
   <class name="moveit_reach_plugins/evaluation/JointPenaltyMoveIt" type="moveit_reach_plugins::evaluation::JointPenaltyMoveIt" base_class_type="reach::plugins::EvaluationBase">

--- a/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
+++ b/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
@@ -17,6 +17,8 @@
 #include "moveit_reach_plugins/utils.h"
 #include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/robot_model/joint_model_group.h>
+
+#include <numeric>
 #include <xmlrpcpp/XmlRpcException.h>
 
 namespace moveit_reach_plugins
@@ -25,6 +27,8 @@ namespace evaluation
 {
 ManipulabilityMoveIt::ManipulabilityMoveIt() : reach::plugins::EvaluationBase()
 {
+  jacobian_row_subset_.resize(6);
+  std::iota(jacobian_row_subset_.begin(), jacobian_row_subset_.end(), 0);
 }
 
 bool ManipulabilityMoveIt::initialize(XmlRpc::XmlRpcValue& config)
@@ -38,12 +42,37 @@ bool ManipulabilityMoveIt::initialize(XmlRpc::XmlRpcValue& config)
   std::string planning_group;
   try
   {
-    planning_group = std::string(config["planning_group"]);
+    planning_group = static_cast<std::string>(config["planning_group"]);
   }
   catch (const XmlRpc::XmlRpcException& ex)
   {
     ROS_ERROR_STREAM(ex.getMessage());
     return false;
+  }
+
+  if (config.hasMember("jacobian_row_subset") &&
+      config["jacobian_row_subset"].getType() == XmlRpc::XmlRpcValue::TypeArray)
+  {
+    std::set<Eigen::Index> subset_rows;
+    for (std::size_t i = 0; i < config["jacobian_row_subset"].size(); ++i)
+    {
+      int row = static_cast<int>(config["jacobian_row_subset"][i]);
+      if (row < 0 || row >= 6)
+      {
+        ROS_ERROR_STREAM("Invalid Jacobian row subset index provided: " << row << ". Must be on interval [0, 6)");
+        return false;
+      }
+
+      subset_rows.insert(row);
+    }
+
+    if (subset_rows.empty())
+    {
+      ROS_ERROR_STREAM("Jacobian row subset is empty");
+      return false;
+    }
+
+    std::copy(subset_rows.begin(), subset_rows.end(), std::back_inserter(jacobian_row_subset_));
   }
 
   model_ = moveit::planning_interface::getSharedRobotModel("robot_description");
@@ -73,7 +102,7 @@ double ManipulabilityMoveIt::calculateScore(const std::map<std::string, double>&
   if (!utils::transcribeInputMap(pose, jmg_->getActiveJointModelNames(), pose_subset))
   {
     ROS_ERROR_STREAM(__FUNCTION__ << ": failed to transcribe input pose map");
-    return 0.0f;
+    return 0.0;
   }
 
   state.setJointGroupPositions(jmg_, pose_subset);
@@ -81,6 +110,18 @@ double ManipulabilityMoveIt::calculateScore(const std::map<std::string, double>&
 
   // Get the Jacobian matrix
   Eigen::MatrixXd jacobian = state.getJacobian(jmg_);
+
+  // Extract the partial jacobian
+  if (jacobian_row_subset_.size() < 6)
+  {
+    Eigen::MatrixXd partial_jacobian(jacobian_row_subset_.size(), jacobian.cols());
+    for (Eigen::Index i = 0; i < jacobian_row_subset_.size(); ++i)
+    {
+      partial_jacobian.row(i) = jacobian.row(jacobian_row_subset_[i]);
+    }
+
+    jacobian = partial_jacobian;
+  }
 
   // Calculate manipulability by multiplying Jacobian matrix singular values together
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(jacobian);

--- a/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
+++ b/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
@@ -85,12 +85,7 @@ double ManipulabilityMoveIt::calculateScore(const std::map<std::string, double>&
   // Calculate manipulability by multiplying Jacobian matrix singular values together
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(jacobian);
   Eigen::MatrixXd singular_values = svd.singularValues();
-  double m = 1.0;
-  for (unsigned int i = 0; i < singular_values.rows(); ++i)
-  {
-    m *= singular_values(i, 0);
-  }
-  return m;
+  return singular_values.array().prod();
 }
 
 }  // namespace evaluation

--- a/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
+++ b/moveit_reach_plugins/src/evaluation/manipulability_moveit.cpp
@@ -123,10 +123,19 @@ double ManipulabilityMoveIt::calculateScore(const std::map<std::string, double>&
     jacobian = partial_jacobian;
   }
 
-  // Calculate manipulability by multiplying Jacobian matrix singular values together
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(jacobian);
   Eigen::MatrixXd singular_values = svd.singularValues();
-  return singular_values.array().prod();
+  return calculateScore(singular_values);
+}
+
+double ManipulabilityMoveIt::calculateScore(const Eigen::MatrixXd& jacobian_singular_values)
+{
+  return jacobian_singular_values.array().prod();
+}
+
+double ManipulabilityRatio::calculateScore(const Eigen::MatrixXd& jacobian_singular_values)
+{
+  return jacobian_singular_values.minCoeff() / jacobian_singular_values.maxCoeff();
 }
 
 }  // namespace evaluation
@@ -134,3 +143,4 @@ double ManipulabilityMoveIt::calculateScore(const std::map<std::string, double>&
 
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS(moveit_reach_plugins::evaluation::ManipulabilityMoveIt, reach::plugins::EvaluationBase)
+PLUGINLIB_EXPORT_CLASS(moveit_reach_plugins::evaluation::ManipulabilityRatio, reach::plugins::EvaluationBase)

--- a/moveit_reach_plugins/src/ik/moveit_ik_solver.cpp
+++ b/moveit_reach_plugins/src/ik/moveit_ik_solver.cpp
@@ -135,11 +135,7 @@ boost::optional<double> MoveItIKSolver::solveIKFromSeed(const Eigen::Isometry3d&
   state.setJointGroupPositions(jmg_, seed_subset);
   state.update();
 
-  const static int SOLUTION_ATTEMPTS = 3;
-  const static double SOLUTION_TIMEOUT = 0.2;
-
-  if (state.setFromIK(jmg_, target, SOLUTION_ATTEMPTS, SOLUTION_TIMEOUT,
-                      boost::bind(&MoveItIKSolver::isIKSolutionValid, this, _1, _2, _3)))
+  if (state.setFromIK(jmg_, target, 0.0, boost::bind(&MoveItIKSolver::isIKSolutionValid, this, _1, _2, _3)))
   {
     solution.clear();
     state.copyJointGroupPositions(jmg_, solution);

--- a/reach_core/include/reach_core/ik_helper.h
+++ b/reach_core/include/reach_core/ik_helper.h
@@ -21,8 +21,7 @@
 #include <reach_core/plugins/ik_solver_base.h>
 
 #include <boost/optional.hpp>
-#include <flann/flann.h>
-#include <flann/algorithms/kdtree_single_index.h>
+#include <pcl/search/kdtree.h>
 
 namespace reach
 {
@@ -34,8 +33,7 @@ struct NeighborReachResult
   double joint_distance = 0;
 };
 
-typedef flann::KDTreeSingleIndex<flann::L2_3D<double>> SearchTree;
-typedef std::shared_ptr<SearchTree> SearchTreePtr;
+using SearchTreePtr = pcl::search::KdTree<pcl::PointXYZ>::Ptr;
 
 NeighborReachResult reachNeighborsDirect(std::shared_ptr<ReachDatabase> db, const reach_msgs::ReachRecord& rec,
                                          reach::plugins::IKSolverBasePtr solver, const double radius,

--- a/reach_core/test/plugin_utest.cpp
+++ b/reach_core/test/plugin_utest.cpp
@@ -22,12 +22,12 @@ public:
   pluginlib::ClassLoader<PluginT> loader;
 };
 
-// Evaluation plugins - 1 in reach_core, 3 in moveit_reach_plugins
+// Evaluation plugins - 1 in reach_core, 4 in moveit_reach_plugins
 template <>
 const std::string PluginTest<reach::plugins::EvaluationBase>::base_class_name = EVAL_PLUGIN_BASE;
 
 template <>
-const unsigned PluginTest<reach::plugins::EvaluationBase>::expected_count = 4;
+const unsigned PluginTest<reach::plugins::EvaluationBase>::expected_count = 5;
 
 // IK Solver plugins - 0 in reach_core, 2 in moveit_reach_plugins
 template <>


### PR DESCRIPTION
Performance updates:
- Switch from unimplemented FLANN nearest neighbor search to PCL FLANN nearest neighbor search; used search tree in reach study loop rather than brute force nearest neighbors search
- Remove the long timeout and multiple attempts from the MoveIt IK solver with the idea that IK is being solved many times at each point from various seeds in the process of the reach study, so there is no reason to duplicate efforts within the IK solver wrapper
- Minor API changes to avoid copying structures unnecessarily
- Added vectorization to some matrix computations

New features:
- Support evaluating a subset of manipulability by specifying the row indices of the Jacobian matrix (corresponding to [x, y, z, rx, ry, rz])
- Added a manipulability-based plugin that evaluates the ratio of the smallest to largest manipulability value to promote uniform dexterity

Other:
- Simplified the calculation of the joint penalty evaluator