### PR TITLE
Updated to later version of plugin loader

### DIFF
--- a/.github/workflows/focal_noetic.yml
+++ b/.github/workflows/focal_noetic.yml
@@ -53,7 +53,7 @@ jobs:
           CI_NAME: focal
           OS_NAME: ubuntu
           OS_CODE_NAME: focal
-          ROS_REPO: main
+          UPSTREAM_WORKSPACE: dependencies.repos
           PREFIX: ${{ github.repository }}_
           CMAKE_ARGS: '-DENABLE_TESTING=ON -DENABLE_RUN_TESTING=OFF'
           BEFORE_RUN_TARGET_TEST_EMBED: 'ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash'

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cd ..
 
 Install the dependencies
 ``` bash
+vcs import src < src/reach/dependencies.repos
 rosdep install --from-paths src --ignore-src -r -y
 ```
 

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,4 @@
+- git:
+   local-name: boost_plugin_loader
+   uri: https://github.com/tesseract-robotics/boost_plugin_loader.git
+   version: 4b033614eb6d49f33d1995c2aeb1f3f691576041


### PR DESCRIPTION
This PR updates the dependency on `boost_plugin_loader` to a later (as yet unreleased on the ROS build farm) version that has better error messaging and handles the search for plugin libraries more correctly