### PR TITLE
Initial IK seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See the [`reach_ros`](https://github.com/ros-industrial/reach_ros) and [`reach_r
     - Additional constraints (or lack thereof, such as orientation freedom about the tool z-axis) can also be incorporated into the IK solver (via parameters or source code changes) to produce different reach study results
     - For `MoveIt`-based plugins, the selection of IK solver is defined in the `kinematics.yaml` file
 1. Reach study results are serialized to file and can be loaded using the API in `reach` for programmatic analysis or modification
+1. You can specify a starting seed for the IK solver by providing a list of joint positions in the config. This be used to help the IK solver to find solutions for complex scenarios. It might also help to guide the solver to solutions that are closer to a certain configuration that you prefere. If no initial seed is provided, a pose with all joints at 0 position is used.
 
 [1]: docs/reach_study.png
 [2]: docs/reach_study_demo.gif

--- a/include/reach/reach_study.h
+++ b/include/reach/reach_study.h
@@ -41,6 +41,7 @@ public:
     float step_improvement_threshold;
     float radius;
     std::size_t max_threads = std::thread::hardware_concurrency();
+    std::map<std::string, double> initial_seed;
   };
 
   ReachStudy(IKSolver::ConstPtr ik_solver, Evaluator::ConstPtr evaluator, TargetPoseGenerator::ConstPtr pose_generator,

--- a/include/reach/reach_study.h
+++ b/include/reach/reach_study.h
@@ -41,7 +41,7 @@ public:
     float step_improvement_threshold;
     float radius;
     std::size_t max_threads = std::thread::hardware_concurrency();
-    std::map<std::string, double> initial_seed;
+    std::map<std::string, double> seed_state;
   };
 
   ReachStudy(IKSolver::ConstPtr ik_solver, Evaluator::ConstPtr evaluator, TargetPoseGenerator::ConstPtr pose_generator,

--- a/src/reach_study.cpp
+++ b/src/reach_study.cpp
@@ -93,13 +93,16 @@ void ReachStudy::run()
 
     // Get the seed position
     std::map<std::string, double> seed_state;
-    if (params_.initial_seed.size() == 0){
+    if (params_.seed_state.empty())
+    {
       // no initialization give, use 0 positions
       const std::vector<std::string> joint_names = ik_solver_->getJointNames();
       seed_state = zip(joint_names, std::vector<double>(joint_names.size(), 0.0));
-    }else{
+    }
+    else
+    {
       // use given initial positions
-      seed_state = params_.initial_seed;
+      seed_state = params_.seed_state;
     }
 
     // Solve IK
@@ -268,13 +271,13 @@ void runReachStudy(const YAML::Node& config, const std::string& config_name, con
     params.max_threads = opt_config["max_threads"].as<std::size_t>();
 
   // read the initial joint positions if specified
-  const YAML::Node initial_seed_yaml = opt_config["initial_seed"];
-  for (auto it = initial_seed_yaml.begin(); it != initial_seed_yaml.end(); ++it)
+  const YAML::Node seed_state_yaml = opt_config["seed_state"];
+  for (auto it = seed_state_yaml.begin(); it != seed_state_yaml.end(); ++it)
   {
-    const YAML::Node& initial_seed_entry = *it;
-    std::string name = reach::get<std::string>(initial_seed_entry, "name");
-    double position = reach::get<double>(initial_seed_entry, "position");
-    params.initial_seed.insert(std::pair<std::string,double>(name, position));
+    const YAML::Node& seed_state_entry = *it;
+    std::string name = reach::get<std::string>(seed_state_entry, "name");
+    double position = reach::get<double>(seed_state_entry, "position");
+    params.seed_state.insert(std::pair<std::string, double>(name, position));
   }
 
   boost_plugin_loader::PluginLoader loader;

--- a/test/reach_study.yaml
+++ b/test/reach_study.yaml
@@ -2,6 +2,21 @@ optimization:
   radius: 0.4
   max_steps: 10
   step_improvement_threshold: 0.01
+  seed_state:
+    - name: j1
+      position: 2.66
+    - name: j2
+      position: -1.54
+    - name: j3
+      position: -0.56
+    - name: j4
+      position: -2.20
+    - name: j5
+      position: -0.32
+    - name: j6
+      position: 1.81
+    - name: j7
+      position: 2.39
 
 ik_solver:
   name: NoOpIKSolver

--- a/test/reach_study.yaml
+++ b/test/reach_study.yaml
@@ -5,18 +5,6 @@ optimization:
   seed_state:
     - name: j1
       position: 2.66
-    - name: j2
-      position: -1.54
-    - name: j3
-      position: -0.56
-    - name: j4
-      position: -2.20
-    - name: j5
-      position: -0.32
-    - name: j6
-      position: 1.81
-    - name: j7
-      position: 2.39
 
 ik_solver:
   name: NoOpIKSolver


### PR DESCRIPTION
This small PR adds an option to specify the initial IK seed.
It was helpful for my use case to be able to specify this, as I am using a high DoF robot and a difficult to reach workpiece.
Maybe it is helpful for others too. If you don't want to add this feature, it is also fine for me.
As long a this parameter is not defined, previous behavior of using the zero pose is used.
For the demo study, one can for example add the following to the `optimization` part of the config yaml (although it does not provide an advantage in this simple case).
```
  initial_seed:
    - name: joint_s
      position: 2.66
    - name: joint_l
      position: -1.54
    - name: joint_e
      position: -0.56
    - name: joint_u
      position: -2.20
    - name: joint_r
      position: -0.32
    - name: joint_b
      position: 1.81
    - name: joint_t
      position: 2.39
```