### PR TITLE
Fix parallelization error of omp parallel

### DIFF
--- a/src/reach_study.cpp
+++ b/src/reach_study.cpp
@@ -165,7 +165,7 @@ void ReachStudy::optimize()
     // Randomize
     std::random_shuffle(rand_vec.begin(), rand_vec.end());
 
-#pragma parallel for num_threads(params_.max_threads)
+#pragma omp parallel for num_threads(params_.max_threads)
     for (std::size_t i = 0; i < rand_vec.size(); ++i)
     {
       const ReachRecord& msg = active_result->at(i);
@@ -218,7 +218,7 @@ std::tuple<double, double> ReachStudy::getAverageNeighborsCount() const
   std::atomic<double> total_joint_distance;
 
 // Iterate
-#pragma parallel for num_threads(params_.max_threads)
+#pragma omp parallel for num_threads(params_.max_threads)
   for (auto it = active_result.begin(); it != active_result.end(); ++it)
   {
     if (it->reached)


### PR DESCRIPTION
I was actually debugging completly different when I looked into the amount of CPU power that is used by REACH. What I then saw was a sudden drop after the first initial reach study. Basically as soon as the first optimization loop starts, only one of the threads is creating CPU load (see screenshot of htop below).
![pragma_parallel_for](https://github.com/ros-industrial/reach/assets/11520148/6c5f08dc-b380-4f30-b4c6-d8394aec9315)

This seemed strange to me. Therefore, I looked in the code and saw that the first for loop (of the initial exploration) has a slightly other `#pragma` statement then the one of the optimization. So I changed all of them to the first one. This resulted then in the other threads also producing load during the optimization runs.
![pragma_omp_parallel_for](https://github.com/ros-industrial/reach/assets/11520148/1162def6-73ad-49c7-8107-0ff5231d7be5)

I am a bit confused what is happening. I understand what `#pragma omp parallel for` does, I just don't know where the difference is to `#pragma parallel for` and the internet also gave me no answer. Therefore, I assumed that this is some weird bug and opened this PR 🤷‍♂️ 