### PR TITLE
Added colcon hook for setting the PYTHONPATH environment variable

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,3 +1,3 @@
 {
-    "hooks": ["share/reach/hook/ament_prefix_path.dsv", "share/reach/hook/ros_package_path.dsv"]
+    "hooks": ["share/reach/hook/ament_prefix_path.dsv", "share/reach/hook/ros_package_path.dsv", "share/reach/hook/python_path.dsv"]
 }

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -13,6 +13,12 @@ set_target_properties(
                                     OUTPUT_NAME ${PROJECT_NAME})
 target_cxx_version(${PROJECT_NAME}_python PUBLIC VERSION 14)
 
+# Add a hook for colcon to add the Python library directory to the PYTHONPATH environment variable
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+     "prepend-non-duplicate;PYTHONPATH;lib/python3/dist-packages")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+        DESTINATION share/${PROJECT_NAME}/hook)
+
 list(
   APPEND
   TARGETS


### PR DESCRIPTION
Fix from [this post](https://answers.ros.org/question/394564/colcon-not-adding-python-module-built-with-cmake-to-pythonpath/) to address #49 