### PR TITLE
Removed -dev libraries before running unit tests in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -60,6 +60,7 @@ jobs:
           AFTER_INIT: './.github/workflows/add_ros_apt_sources.sh'
           TARGET_CMAKE_ARGS: '-DENABLE_TESTING=ON -DENABLE_RUN_TESTING=OFF -DCMAKE_BUILD_TYPE=Release'
           AFTER_INSTALL_TARGET_DEPENDENCIES: 'python3 -m pip install -r requirements.txt -qq'
+          BEFORE_RUN_TARGET_TEST: 'apt remove *-dev -y -qq'
           BEFORE_RUN_TARGET_TEST_EMBED: 'ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash'
           AFTER_RUN_TARGET_TEST: 'python3 -m pytest -v'
           AFTER_SCRIPT: 'rm -r $BASEDIR/${PREFIX}upstream_ws/build $BASEDIR/${PREFIX}target_ws/build'


### PR DESCRIPTION
Changes per commit message to further reduce size of CI-produced docker image