### PR TITLE
Exposed relevant compile definitions for plugins to the Python interface

### DIFF
--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -313,6 +313,9 @@ BOOST_PYTHON_MODULE(MODULE_NAME)
     bp::register_ptr_to_python<TargetPoseGenerator::ConstPtr>();
     bp::register_ptr_to_python<TargetPoseGeneratorFactory::Ptr>();
   }
+
+  // Export relevant compile definitions
+  bp::scope().attr("SEARCH_LIBRARIES_ENV") = SEARCH_LIBRARIES_ENV;
 }
 
 }  // namespace reach


### PR DESCRIPTION
Changes per commit message to support easier usage in Python. For downstream pure-Python applications, this allows you to set the `SEARCH_LIBRARIES_ENV` environment variable inside a Python script to find custom plugins without having to hard-code the environment variable name:
```diff
-os.environ['REACH_PLUGINS'] = '<plugin_library_name>:<...>:<...>'
+os.environ[reach.SEARCH_LIBRARIES_ENV] = '<plugin_library_name>:<...>:<...>'
```