### PR TITLE
Add option for red to green color scale

### DIFF
--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -124,7 +124,7 @@ std::vector<float> normalizeScores(const ReachResult& result, bool use_full_rang
  * @param scores Vector of reach target scores in the range [0, 1]
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores);
+Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, bool use_red_to_green = false);
 
 /**
  * @brief Computes heat map colors for the reach targets in a reach study result
@@ -134,7 +134,7 @@ Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores);
  * before colorization
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range);
+Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, bool use_red_to_green);
 
 class ReachDatabase
 {
@@ -144,7 +144,7 @@ public:
 
   bool operator==(const ReachDatabase& rhs) const;
   ReachResultSummary calculateResults() const;
-  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false) const;
+  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false, bool use_red_to_green = false) const;
 
 private:
   friend class boost::serialization::access;

--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -124,7 +124,8 @@ std::vector<float> normalizeScores(const ReachResult& result, bool use_full_rang
  * @param scores Vector of reach target scores in the range [0, 1]
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hue_low_score = 270.0f, float hue_high_score = 0.0f);
+Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hue_low_score = 270.0f,
+                                      float hue_high_score = 0.0f);
 
 /**
  * @brief Computes heat map colors for the reach targets in a reach study result
@@ -134,8 +135,8 @@ Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hu
  * before colorization
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, float hue_low_score = 270.0f,
-                                      float hue_high_score = 0.0f);
+Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range,
+                                      float hue_low_score = 270.0f, float hue_high_score = 0.0f);
 
 class ReachDatabase
 {

--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -124,7 +124,7 @@ std::vector<float> normalizeScores(const ReachResult& result, bool use_full_rang
  * @param scores Vector of reach target scores in the range [0, 1]
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, bool use_red_to_green = false);
+Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hue_low_score, float hue_high_score);
 
 /**
  * @brief Computes heat map colors for the reach targets in a reach study result
@@ -134,7 +134,8 @@ Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, bool use
  * before colorization
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, bool use_red_to_green);
+Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, float hue_low_score,
+                                      float hue_high_score);
 
 class ReachDatabase
 {
@@ -144,7 +145,8 @@ public:
 
   bool operator==(const ReachDatabase& rhs) const;
   ReachResultSummary calculateResults() const;
-  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false, bool use_red_to_green = false) const;
+  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false, float hue_low_score = 270.0,
+                                        float hue_high_score = 0.0) const;
 
 private:
   friend class boost::serialization::access;

--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -124,7 +124,7 @@ std::vector<float> normalizeScores(const ReachResult& result, bool use_full_rang
  * @param scores Vector of reach target scores in the range [0, 1]
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hue_low_score, float hue_high_score);
+Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hue_low_score = 270.0f, float hue_high_score = 0.0f);
 
 /**
  * @brief Computes heat map colors for the reach targets in a reach study result
@@ -134,8 +134,8 @@ Eigen::MatrixX3f computeHeatMapColors(const std::vector<float>& scores, float hu
  * before colorization
  * @return An array of RGB colors on [0, 1] for each channel
  */
-Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, float hue_low_score,
-                                      float hue_high_score);
+Eigen::MatrixX3f computeHeatMapColors(const ReachResult& result, bool use_full_color_range, float hue_low_score = 270.0f,
+                                      float hue_high_score = 0.0f);
 
 class ReachDatabase
 {

--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -145,8 +145,8 @@ public:
 
   bool operator==(const ReachDatabase& rhs) const;
   ReachResultSummary calculateResults() const;
-  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false, float hue_low_score = 270.0,
-                                        float hue_high_score = 0.0) const;
+  Eigen::MatrixX3f computeHeatMapColors(bool use_full_color_range = false, float hue_low_score = 270.0f,
+                                        float hue_high_score = 0.0f) const;
 
 private:
   friend class boost::serialization::access;

--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -128,14 +128,14 @@ bp::list normalizeScoresPython(const ReachResult& result, bool use_full_range)
   return out;
 }
 
-np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, float hue_low_score,
-                                        float hue_high_score)
+np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, float hue_low_score = 270.0f,
+                                        float hue_high_score = 0.0f)
 {
   return fromEigen<float, Eigen::Dynamic, 3>(
       computeHeatMapColors(result, use_full_color_range, hue_low_score, hue_high_score));
 }
 
-np::ndarray computeHeatMapColorsPython2(const bp::list& scores, float hue_low_score, float hue_high_score)
+np::ndarray computeHeatMapColorsPython2(const bp::list& scores, float hue_low_score = 270.0f, float hue_high_score = 0.0f)
 {
   std::vector<float> scores_v;
   scores_v.reserve(bp::len(scores));

--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -128,14 +128,15 @@ bp::list normalizeScoresPython(const ReachResult& result, bool use_full_range)
   return out;
 }
 
-np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, float hue_low_score = 270.0f,
-                                        float hue_high_score = 0.0f)
+np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range,
+                                        float hue_low_score = 270.0f, float hue_high_score = 0.0f)
 {
   return fromEigen<float, Eigen::Dynamic, 3>(
       computeHeatMapColors(result, use_full_color_range, hue_low_score, hue_high_score));
 }
 
-np::ndarray computeHeatMapColorsPython2(const bp::list& scores, float hue_low_score = 270.0f, float hue_high_score = 0.0f)
+np::ndarray computeHeatMapColorsPython2(const bp::list& scores, float hue_low_score = 270.0f,
+                                        float hue_high_score = 0.0f)
 {
   std::vector<float> scores_v;
   scores_v.reserve(bp::len(scores));

--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -128,19 +128,19 @@ bp::list normalizeScoresPython(const ReachResult& result, bool use_full_range)
   return out;
 }
 
-np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range)
+np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, bool use_red_to_green)
 {
-  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(result, use_full_color_range));
+  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(result, use_full_color_range, use_red_to_green));
 }
 
-np::ndarray computeHeatMapColorsPython2(const bp::list& scores)
+np::ndarray computeHeatMapColorsPython2(const bp::list& scores, bool use_red_to_green)
 {
   std::vector<float> scores_v;
   scores_v.reserve(bp::len(scores));
   for (bp::ssize_t i = 0; i < bp::len(scores); ++i)
     scores_v.push_back(bp::extract<float>{ scores[i] }());
 
-  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(scores_v));
+  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(scores_v, use_red_to_green));
 }
 
 BOOST_PYTHON_MODULE(MODULE_NAME)

--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -128,19 +128,21 @@ bp::list normalizeScoresPython(const ReachResult& result, bool use_full_range)
   return out;
 }
 
-np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, bool use_red_to_green)
+np::ndarray computeHeatMapColorsPython1(const ReachResult& result, bool use_full_color_range, float hue_low_score,
+                                        float hue_high_score)
 {
-  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(result, use_full_color_range, use_red_to_green));
+  return fromEigen<float, Eigen::Dynamic, 3>(
+      computeHeatMapColors(result, use_full_color_range, hue_low_score, hue_high_score));
 }
 
-np::ndarray computeHeatMapColorsPython2(const bp::list& scores, bool use_red_to_green)
+np::ndarray computeHeatMapColorsPython2(const bp::list& scores, float hue_low_score, float hue_high_score)
 {
   std::vector<float> scores_v;
   scores_v.reserve(bp::len(scores));
   for (bp::ssize_t i = 0; i < bp::len(scores); ++i)
     scores_v.push_back(bp::extract<float>{ scores[i] }());
 
-  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(scores_v, use_red_to_green));
+  return fromEigen<float, Eigen::Dynamic, 3>(computeHeatMapColors(scores_v, hue_low_score, hue_high_score));
 }
 
 BOOST_PYTHON_MODULE(MODULE_NAME)


### PR DESCRIPTION
I understand that the current color scale should show a heatmap. However, everytime I showed an image to one of my coworkers, they were confused by the colors. They always expected areas with low score as red and areas with good score as green. Especially in combination with the RViz visualization.
Therefore, I implemented an option to switch from the heatmap color scheme to a red to green color scaling.
I don't know, if you want to have this in the main code base. If not, then that is also totally fine for me and you can close this PR.
If you want to merge it, I can also add some documentation to the PR.

Previous color scheme (with use_full_color_range)
![standard](https://github.com/ros-industrial/reach/assets/11520148/93a023c7-5e04-4842-8e52-73924ec1565d)

New red to green option (with use_full_color_range)
![red_to_green](https://github.com/ros-industrial/reach/assets/11520148/dfce54ee-7663-46cb-8940-9721114a019e)
