### PR TITLE
Add seed state checks

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   clang_format:
     name: Clang-Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cmake_format:
     name: CMake-Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 

--- a/include/reach/reach_study.h
+++ b/include/reach/reach_study.h
@@ -85,6 +85,12 @@ public:
   std::tuple<double, double> getAverageNeighborsCount() const;
 
 protected:
+  /**
+   * @brief Checks the seed state parameter for validity and sets it to a default value if it does not exist
+   * @throws Throws an exception if all of the IK solver joint names cannot be found in the seed state parameter
+   */
+  void checkSeedState();
+
   Parameters params_;
   ReachDatabase db_;
 

--- a/include/reach/utils.h
+++ b/include/reach/utils.h
@@ -61,9 +61,9 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& msg, IKSo
                              SearchTreePtr search_tree = nullptr);
 
 /**
- * @brief Extracts the vector of values from the input map that correspond to the ordered input keys
+ * @brief Extracts the subset vector of values from the input map that correspond to the ordered input keys
  */
-std::vector<double> transcribeInputMap(const std::map<std::string, double>& input,
+std::vector<double> extractSubset(const std::map<std::string, double>& input,
                                        const std::vector<std::string>& keys);
 
 }  // namespace reach

--- a/include/reach/utils.h
+++ b/include/reach/utils.h
@@ -63,8 +63,7 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& msg, IKSo
 /**
  * @brief Extracts the subset vector of values from the input map that correspond to the ordered input keys
  */
-std::vector<double> extractSubset(const std::map<std::string, double>& input,
-                                       const std::vector<std::string>& keys);
+std::vector<double> extractSubset(const std::map<std::string, double>& input, const std::vector<std::string>& keys);
 
 }  // namespace reach
 

--- a/include/reach/utils.h
+++ b/include/reach/utils.h
@@ -60,6 +60,12 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& msg, IKSo
                              Evaluator::ConstPtr evaluator, const double radius, NeighborReachResult& result,
                              SearchTreePtr search_tree = nullptr);
 
+/**
+ * @brief Extracts the vector of values from the input map that correspond to the ordered input keys
+ */
+std::vector<double> transcribeInputMap(const std::map<std::string, double>& input,
+                                       const std::vector<std::string>& keys);
+
 }  // namespace reach
 
 #endif  // REACH_UTILS_GENERAL_UTILS_H

--- a/src/reach_study.cpp
+++ b/src/reach_study.cpp
@@ -38,6 +38,7 @@ ReachStudy::ReachStudy(IKSolver::ConstPtr ik_solver, Evaluator::ConstPtr evaluat
   , target_poses_(target_generator->generate())
   , search_tree_(createSearchTree(target_poses_))
 {
+  checkSeedState();
 }
 
 ReachStudy::ReachStudy(const ReachStudy& rhs)
@@ -49,6 +50,23 @@ ReachStudy::ReachStudy(const ReachStudy& rhs)
   , target_poses_(rhs.target_poses_)
   , search_tree_(rhs.search_tree_)
 {
+  checkSeedState();
+}
+
+void ReachStudy::checkSeedState()
+{
+  // Check the optional seed state parameter
+  const std::vector<std::string> joint_names = ik_solver_->getJointNames();
+  if(params_.seed_state.empty())
+  {
+    logger_->print("Seed state is empty; setting to all-zeros state");
+    params_.seed_state = zip(joint_names, std::vector<double>(joint_names.size(), 0.0));
+  }
+  else
+  {
+    // Attempt to extract a subset of the seed state for the provided joint names. This function throws an exception if this is not possible
+    transcribeInputMap(params_.seed_state, joint_names);
+  }
 }
 
 void ReachStudy::load(const std::string& filename)

--- a/src/reach_study.cpp
+++ b/src/reach_study.cpp
@@ -65,7 +65,7 @@ void ReachStudy::checkSeedState()
   else
   {
     // Attempt to extract a subset of the seed state for the provided joint names. This function throws an exception if this is not possible
-    transcribeInputMap(params_.seed_state, joint_names);
+    extractSubset(params_.seed_state, joint_names);
   }
 }
 

--- a/src/reach_study.cpp
+++ b/src/reach_study.cpp
@@ -57,14 +57,15 @@ void ReachStudy::checkSeedState()
 {
   // Check the optional seed state parameter
   const std::vector<std::string> joint_names = ik_solver_->getJointNames();
-  if(params_.seed_state.empty())
+  if (params_.seed_state.empty())
   {
     logger_->print("Seed state is empty; setting to all-zeros state");
     params_.seed_state = zip(joint_names, std::vector<double>(joint_names.size(), 0.0));
   }
   else
   {
-    // Attempt to extract a subset of the seed state for the provided joint names. This function throws an exception if this is not possible
+    // Attempt to extract a subset of the seed state for the provided joint names. This function throws an exception if
+    // this is not possible
     extractSubset(params_.seed_state, joint_names);
   }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -203,4 +203,25 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& rec, IKSo
   }
 }
 
+std::vector<double> transcribeInputMap(const std::map<std::string, double>& input,
+                                       const std::vector<std::string>& keys)
+{
+  if (keys.size() > input.size())
+    throw std::runtime_error("Input map size was not at least as large as the number of keys");
+
+  // Pull the joints of the planning group out of the input map
+  std::vector<double> values;
+  values.reserve(keys.size());
+  for (const std::string& name : keys)
+  {
+    const auto it = input.find(name);
+    if (it == input.end())
+      throw std::runtime_error("Key '" + name + "' is not in the input map");
+
+    values.push_back(it->second);
+  }
+
+  return values;
+}
+
 }  // namespace reach

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -203,8 +203,7 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& rec, IKSo
   }
 }
 
-std::vector<double> extractSubset(const std::map<std::string, double>& input,
-                                       const std::vector<std::string>& keys)
+std::vector<double> extractSubset(const std::map<std::string, double>& input, const std::vector<std::string>& keys)
 {
   if (keys.size() > input.size())
     throw std::runtime_error("Input map size was not at least as large as the number of keys");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -203,7 +203,7 @@ void reachNeighborsRecursive(const ReachResult& db, const ReachRecord& rec, IKSo
   }
 }
 
-std::vector<double> transcribeInputMap(const std::map<std::string, double>& input,
+std::vector<double> extractSubset(const std::map<std::string, double>& input,
                                        const std::vector<std::string>& keys)
 {
   if (keys.size() > input.size())


### PR DESCRIPTION
This PR adds checks to `params_.seed_state` to ensure that it has the proper entries. The MoveIt-based solvers crash if the seed state does not include the motion group's joints. There is currently a check in the [`runReachStudy` c++ function](https://github.com/ros-industrial/reach/blob/c9348ee151e92a71f4c2660b6d62cfa8b63cce71/src/reach_study.cpp#L271-L292), but this check does not currently happen if a reach study is constructed manually in Python, like [here](https://github.com/ros-industrial/reach/blob/c9348ee151e92a71f4c2660b6d62cfa8b63cce71/scripts/test_reach.py#L79-L110).