### PR TITLE
Make NoOpEvaluator return 1.0

### DIFF
--- a/scripts/test_reach.py
+++ b/scripts/test_reach.py
@@ -156,9 +156,9 @@ class ReachStudyFixture(unittest.TestCase):
 
         results = db.calculateResults()
         logger.printResults(results)
-        self.assertAlmostEqual(results.total_pose_score, 0.0)
+        self.assertAlmostEqual(results.total_pose_score, 100.0)
         self.assertAlmostEqual(results.reach_percentage, 100.0)
-        self.assertAlmostEqual(results.norm_total_pose_score, 0.0)
+        self.assertAlmostEqual(results.norm_total_pose_score, 100.0)
 
         display.showEnvironment()
 

--- a/src/plugins/no_op.cpp
+++ b/src/plugins/no_op.cpp
@@ -4,7 +4,7 @@ namespace reach
 {
 double NoOpEvaluator::calculateScore(const std::map<std::string, double>&) const
 {
-  return 0.0;
+  return 1.0;
 }
 
 Evaluator::ConstPtr NoOpEvaluatorFactory::create(const YAML::Node&) const


### PR DESCRIPTION
This makes the `NoOpEvaluator` return 1.0. The advantage is that the `NoOpEvaluator` can then be used for viewing whether the poses are reachable, for example in the `ROSDisplay`, the reachable poses are shown in red and the unreachable poses in black. I would argue that the evaluator would still be `NoOp` but then would also have a practical use.