### PR TITLE
Replace deprecated usages of boost

### DIFF
--- a/include/reach/plugins/boost_progress_console_logger.h
+++ b/include/reach/plugins/boost_progress_console_logger.h
@@ -18,7 +18,6 @@
 
 #include <reach/interfaces/logger.h>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/timer/progress_display.hpp>
 #include <mutex>
 
@@ -39,7 +38,7 @@ public:
 
 protected:
   mutable std::mutex mutex_;
-  mutable boost::shared_ptr<boost::timer::progress_display> display_;
+  mutable std::shared_ptr<boost::timer::progress_display> display_;
 };
 
 struct BoostProgressConsoleLoggerFactory : public LoggerFactory

--- a/include/reach/plugins/boost_progress_console_logger.h
+++ b/include/reach/plugins/boost_progress_console_logger.h
@@ -19,7 +19,7 @@
 #include <reach/interfaces/logger.h>
 
 #include <boost/shared_ptr.hpp>
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 #include <mutex>
 
 namespace reach
@@ -39,7 +39,7 @@ public:
 
 protected:
   mutable std::mutex mutex_;
-  mutable boost::shared_ptr<boost::progress_display> display_;
+  mutable boost::shared_ptr<boost::timer::progress_display> display_;
 };
 
 struct BoostProgressConsoleLoggerFactory : public LoggerFactory

--- a/include/reach/plugins/no_op.h
+++ b/include/reach/plugins/no_op.h
@@ -20,8 +20,6 @@
 #include <reach/interfaces/ik_solver.h>
 #include <reach/interfaces/display.h>
 
-#include <boost/shared_ptr.hpp>
-
 namespace reach
 {
 struct NoOpEvaluator : public Evaluator

--- a/include/reach/reach_visualizer.h
+++ b/include/reach/reach_visualizer.h
@@ -21,8 +21,6 @@
 #include <reach/interfaces/ik_solver.h>
 #include <reach/utils.h>
 
-#include <boost/shared_ptr.hpp>
-
 namespace reach
 {
 /**
@@ -32,7 +30,7 @@ namespace reach
 class ReachVisualizer
 {
 public:
-  using Ptr = boost::shared_ptr<ReachVisualizer>;
+  using Ptr = std::shared_ptr<ReachVisualizer>;
 
   ReachVisualizer(ReachResult result, IKSolver::ConstPtr solver, Evaluator::ConstPtr evaluator,
                   Display::ConstPtr display, const double neighbor_radius);

--- a/src/plugins/boost_progress_console_logger.cpp
+++ b/src/plugins/boost_progress_console_logger.cpp
@@ -1,7 +1,6 @@
 #include <reach/plugins/boost_progress_console_logger.h>
 #include <reach/types.h>
 
-#include <boost/make_shared.hpp>
 #include <iostream>
 
 namespace reach
@@ -13,7 +12,7 @@ BoostProgressConsoleLogger::BoostProgressConsoleLogger() : display_(nullptr)
 void BoostProgressConsoleLogger::setMaxProgress(unsigned long max_progress)
 {
   std::lock_guard<std::mutex> lock{ mutex_ };
-  display_ = boost::make_shared<boost::timer::progress_display>(max_progress);
+  display_ = std::make_shared<boost::timer::progress_display>(max_progress);
 }
 
 void BoostProgressConsoleLogger::printProgress(unsigned long progress) const

--- a/src/plugins/boost_progress_console_logger.cpp
+++ b/src/plugins/boost_progress_console_logger.cpp
@@ -13,7 +13,7 @@ BoostProgressConsoleLogger::BoostProgressConsoleLogger() : display_(nullptr)
 void BoostProgressConsoleLogger::setMaxProgress(unsigned long max_progress)
 {
   std::lock_guard<std::mutex> lock{ mutex_ };
-  display_ = boost::make_shared<boost::progress_display>(max_progress);
+  display_ = boost::make_shared<boost::timer::progress_display>(max_progress);
 }
 
 void BoostProgressConsoleLogger::printProgress(unsigned long progress) const


### PR DESCRIPTION
* `boost::progress_display` is deprecated and replaced by `boost::timer::progress_display`
* `std::shared_ptr` can be used instead of `boost::shared_ptr` because the project is using C++ >= 11