### PR TITLE
Fix CMake error about missing target MPI::MPI_C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.0)
 # Extract package name and version from package.xml
 find_package(ros_industrial_cmake_boilerplate REQUIRED)
 extract_package_metadata(pkg)
-project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX C)
 
 option(BUILD_PYTHON "Build Python bindings" ON)
 


### PR DESCRIPTION
On Ubuntu 24.04, I am getting the following CMake error when building reach:
```
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/vtk-9.1/VTK-targets.cmake:523 (set_target_properties):
  The link interface of target "VTK::mpi" contains:

    MPI::MPI_C

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/vtk-9.1/vtk-config.cmake:139 (include)
  /lib/x86_64-linux-gnu/cmake/pcl/PCLConfig.cmake:275 (find_package)
  /lib/x86_64-linux-gnu/cmake/pcl/PCLConfig.cmake:324 (find_VTK)
  /lib/x86_64-linux-gnu/cmake/pcl/PCLConfig.cmake:569 (find_external_library)
  CMakeLists.txt:19 (find_package)
```

I am aware that the issue lies somewhere else in the package chain, but I am not sure where. Adding `C` to the project languages makes CMake discover `MPI::MPI_C` as well, resolving the issue, so I propose this fix.