### PR TITLE
Fix 24.04 build. Suppress boost warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,8 @@ target_link_libraries(
          ${PCL_LIBRARIES}
          OpenMP::OpenMP_CXX)
 target_compile_definitions(${PROJECT_NAME} PUBLIC SEARCH_LIBRARIES_ENV="REACH_PLUGINS"
-                                                  PLUGIN_LIBRARIES="${PROJECT_NAME}_plugins")
+                                                  PLUGIN_LIBRARIES="${PROJECT_NAME}_plugins"
+                                                  BOOST_TIMER_ENABLE_DEPRECATED=1)
 target_cxx_version(${PROJECT_NAME} PUBLIC VERSION 14)
 list(APPEND TARGETS ${PROJECT_NAME})
 


### PR DESCRIPTION
Related https://github.com/ros-industrial/reach_ros2/pull/38

Ubuntu 24.04, Boost 1.83 (from apt) produces following error. Fix by suppressing this warning.

```
In file included from /home/rsokolkov/tmp/reach_ws/src/reach/include/reach/plugins/boost_progress_console_logger.h:22,
                 from /home/rsokolkov/tmp/reach_ws/src/reach/src/plugins/boost_progress_console_logger.cpp:1:
/usr/include/boost/progress.hpp:23:3: error: #error This header is deprecated and will be removed. (You can define BOOST_TIMER_ENABLE_DEPRECATED to suppress this error.)
   23 | # error This header is deprecated and will be removed. (You can define BOOST_TIMER_ENABLE_DEPRECATED to suppress this error.)
      |   ^~~~~
In file included from /usr/include/boost/progress.hpp:29:
/usr/include/boost/timer.hpp:21:3: error: #error This header is deprecated and will be removed. (You can define BOOST_TIMER_ENABLE_DEPRECATED to suppress this error.)
   21 | # error This header is deprecated and will be removed. (You can define BOOST_TIMER_ENABLE_DEPRECATED to suppress this error.)
      |   ^~~~~
gmake[2]: *** [CMakeFiles/reach.dir/build.make:202: CMakeFiles/reach.dir/src/plugins/boost_progress_console_logger.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
/home/rsokolkov/tmp/reach_ws/src/reach/src/reach_study.cpp: In member function ‘void reach::ReachStudy::optimize()’:
/home/rsokolkov/tmp/reach_ws/src/reach/src/reach_study.cpp:181:24: warning: ‘void std::random_shuffle(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<long unsigned int*, vector<long unsigned int> >]’ is deprecated: us
e 'std::shuffle' instead [-Wdeprecated-declarations]
  181 |     std::random_shuffle(rand_vec.begin(), rand_vec.end());
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/13/functional:67,
                 from /usr/include/eigen3/Eigen/Core:85,
                 from /usr/include/eigen3/Eigen/Dense:1,
                 from /home/rsokolkov/tmp/reach_ws/src/reach/include/reach/types.h:23,
                 from /home/rsokolkov/tmp/reach_ws/src/reach/include/reach/interfaces/display.h:19,
                 from /home/rsokolkov/tmp/reach_ws/src/reach/include/reach/reach_study.h:19,
                 from /home/rsokolkov/tmp/reach_ws/src/reach/src/reach_study.cpp:16:
/usr/include/c++/13/bits/stl_algo.h:4581:5: note: declared here
 4581 |     random_shuffle(_RandomAccessIterator __first, _RandomAccessIterator __last)
      |     ^~~~~~~~~~~~~~
gmake[1]: *** [CMakeFiles/Makefile2:106: CMakeFiles/reach.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```
