### PR TITLE
Introduce points_reached to ReachResultSummary

### DIFF
--- a/include/reach/types.h
+++ b/include/reach/types.h
@@ -75,6 +75,9 @@ private:
 class ReachResultSummary
 {
 public:
+  /** @brief The number of target poses that were reachable */
+  float points_reached = 0.0f;
+
   /**
    * @brief The total pose score for all reachable points
    * @details This score is generally only significant relative to the score of a different reach study using the same
@@ -96,6 +99,7 @@ public:
   {
     std::stringstream ss;
     ss << "------------------------------------------------\n";
+    ss << "Points Reached = " << points_reached << "\n";
     ss << "Percent Reached = " << reach_percentage << "\n";
     ss << "Total points score = " << total_pose_score << "\n";
     ss << "Normalized total points score = " << norm_total_pose_score << "\n";

--- a/src/python/python_bindings.cpp
+++ b/src/python/python_bindings.cpp
@@ -273,6 +273,7 @@ BOOST_PYTHON_MODULE(MODULE_NAME)
         .def("computeHeatMapColors", &ReachDatabase::computeHeatMapColors);
 
     bp::class_<ReachResultSummary>("ReachResultSummary")
+        .def_readonly("reached_points", &ReachResultSummary::points_reached)
         .def_readonly("total_pose_score", &ReachResultSummary::total_pose_score)
         .def_readonly("norm_total_pose_score", &ReachResultSummary::norm_total_pose_score)
         .def_readonly("reach_percentage", &ReachResultSummary::reach_percentage)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -104,6 +104,7 @@ ReachResultSummary calculateResults(const ReachResult& db)
   const float pct_success = static_cast<float>(success) / static_cast<float>(total);
 
   ReachResultSummary results;
+  results.points_reached = success;
   results.reach_percentage = 100.0f * pct_success;
   results.total_pose_score = score;
   results.norm_total_pose_score = score / pct_success;


### PR DESCRIPTION
Per https://github.com/ros-industrial/reach/discussions/33 in our _use case_ we required a _preset_ of points by generating the pcd without a mesh.

In this case knowing the amount of points for which a solution has been generated was useful to understand the ideal configuration of the robot. 

Probably the _use case_ is out of scope in relation to the main focus of the package (work with meshes in which the amount of points reached does not represent an useful information) so it may not be something ideal to merge. Leaving this PR here in case it is interesting to merge or for anyone.

Cheers.